### PR TITLE
Added Spotify as a Metadata Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,26 @@ A _headless_ Discord Rich Presence client for [Navidrome](https://www.navidrome.
 
 Create an .env file with the following variables:
 
-| Variable           | Description                | Example value                    |
-| ------------------ | -------------------------- | -------------------------------- |
-| DISCORD_CLIENT_ID  | Your Discord app ID        | 805831541070495744               |
-| DISCORD_TOKEN      | Your Discord account token | Mzg5NjkzNzA5MzQ4MTQ2NzY4.DM9aRQ  |
-| LASTFM_API_KEY     | Your last.fm API key       | 098f6bcd4621d373cade4e832627b4f6 |
-| NAVIDROME_SERVER   | Your ND server URL         | https://music.logix.lol          |
-| NAVIDROME_USERNAME | Your ND username           | logix                            |
-| NAVIDROME_PASSWORD | Your ND password           | 66_CfZh8                         |
+| Variable              | Description                | Example value                    |
+| --------------------- | -------------------------- | -------------------------------- |
+| DISCORD_CLIENT_ID     | Your Discord app ID        | 805831541070495744               |
+| DISCORD_TOKEN         | Your Discord account token | Mzg5NjkzNzA5MzQ4MTQ2NzY4.DM9aRQ  |
+| LASTFM_API_KEY        | Your last.fm API key       | 098f6bcd4621d373cade4e832627b4f6 |
+| NAVIDROME_SERVER      | Your ND server URL         | https://music.logix.lol          |
+| NAVIDROME_USERNAME    | Your ND username           | logix                            |
+| NAVIDROME_PASSWORD    | Your ND password           | 66_CfZh8                         |
+| SPOTIFY_CLIENT_ID     | Your Spotify Client ID     | 098f6bcd4621d373cade4e832627b4f6 |
+| SPOTIFY_CLIENT_SECRET | Your Spotify Client Secret | 098f6bcd4621d373cade4e832627b4f6 |
 
 ## 👀 Other setup
 
 There are also a few other variables that can be set in the environment file:
 
-| Variable      | Description                                   | Possible Values                  |
-| ------------- | --------------------------------------------- | -------------------------------- |
-| ACTIVITY_NAME | Sets the activity name                        | ARTIST, ALBUM, TRACK, any string |
-| POLLING_TIME  | How frequently we ask ND what song is playing | Any positive integer             |
+| Variable          | Description                                   | Possible Values                  |
+| ----------------- | --------------------------------------------- | -------------------------------- |
+| ACTIVITY_NAME     | Sets the activity name                        | ARTIST, ALBUM, TRACK, any string |
+| POLLING_TIME      | How frequently we ask ND what song is playing | Any positive integer             |
+| METADATA_PROVIDER | Choose where metadata comes from              | LASTFM, SPOTIFY                  |
 
 ## 🚀 Run the server
 

--- a/config.py
+++ b/config.py
@@ -1,19 +1,25 @@
 from dotenv import load_dotenv
 from os import getenv
-
 load_dotenv()
 
 ACTIVITY_NAME = (
     getenv("ACTIVITY_NAME") or "ARTIST"
 )  # ARTIST | ALBUM | TRACK | (anything else for normal text)
-
 POLLING_TIME = int(getenv("POLLING_TIME") or 1)
-
 DISCORD_CLIENT_ID = getenv("DISCORD_CLIENT_ID")
 DISCORD_TOKEN = getenv("DISCORD_TOKEN")
+
+# Metadata provider: LASTFM or SPOTIFY
+METADATA_PROVIDER = getenv("METADATA_PROVIDER") or "LASTFM"
+
+# Last.fm credentials
 LASTFM_API_KEY = getenv("LASTFM_API_KEY")
 
-# don't forget http(s):// and no trailing slash
-NAVIDROME_SERVER = getenv("NAVIDROME_SERVER")
+# Spotify credentials
+SPOTIFY_CLIENTID = getenv("SPOTIFY_CLIENT_ID")
+SPOTIFY_CLIENTSECRET = getenv("SPOTIFY_CLIENT_SECRET")
+
+# Navidrome settings
+NAVIDROME_SERVER = getenv("NAVIDROME_SERVER")  # don't forget http(s):// and no trailing slash
 NAVIDROME_USERNAME = getenv("NAVIDROME_USERNAME")
 NAVIDROME_PASSWORD = getenv("NAVIDROME_PASSWORD")

--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ import os
 
 from rpc import DiscordRPC
 
+if config.METADATA_PROVIDER.upper() == "SPOTIFY":
+    import spotipy
+    from spotipy.oauth2 import SpotifyClientCredentials
+
 
 class PersistentStore:
     data = {}
@@ -68,6 +72,21 @@ class CurrentTrack:
     ends_at = None
 
     image_url = None
+
+    spotify_client = None
+    if config.METADATA_PROVIDER.upper() == "SPOTIFY":
+        try:
+            if not config.SPOTIFY_CLIENTID or not config.SPOTIFY_CLIENTSECRET:
+                print("Error: SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set")
+            else:
+                auth_manager = SpotifyClientCredentials(
+                    client_id=config.SPOTIFY_CLIENTID,
+                    client_secret=config.SPOTIFY_CLIENTSECRET
+                )
+                spotify_client = spotipy.Spotify(auth_manager=auth_manager)
+                print("Spotify metadata provider initialized")
+        except Exception as e:
+            print(f"Failed to initialize Spotify client: {e}")
 
     def _filter_nowplaying(entry):
         return [
@@ -181,17 +200,80 @@ class CurrentTrack:
 
             PersistentStore.set(cls.album_id, image_url)
 
+
+    @classmethod
+    def _grab_spotify(cls):
+        if not cls.spotify_client:
+            print("Spotify client not initialized")
+            return
+
+        if PersistentStore.has(cls.album_id):
+            cls.set(image_url=PersistentStore.get(cls.album_id))
+            return
+
+        try:
+            search_strategies = [
+                ("album", f"artist:{cls.artist} album:{cls.album}"),
+                ("album", f"{cls.artist} {cls.album}"),
+                ("track", f"artist:{cls.artist} track:{cls.title}"),
+                ("track", f"{cls.artist} {cls.title}"),
+                ("album", cls.album),
+            ]
+
+            image_url = None
+            
+            for search_type, query in search_strategies:
+                try:
+                    results = cls.spotify_client.search(q=query, type=search_type, limit=1)
+                    
+                    if search_type == "album" and results["albums"]["items"]:
+                        album = results["albums"]["items"][0]
+                        if album["images"]:
+                            image_url = album["images"][0]["url"]
+                            print(f"Found album art via query: {query}")
+                            break
+                    elif search_type == "track" and results["tracks"]["items"]:
+                        track = results["tracks"]["items"][0]
+                        if track["album"]["images"]:
+                            image_url = track["album"]["images"][0]["url"]
+                            print(f"Found album art via track query: {query}")
+                            break
+                except Exception as e:
+                    print(f"Search failed for query '{query}': {e}")
+                    continue
+
+            if image_url:
+                cls.set(image_url=image_url)
+                PersistentStore.set(cls.album_id, image_url)
+            else:
+                print(f"No Spotify results found after trying all strategies for: {cls.artist} - {cls.album} - {cls.title}")
+                cls.set(image_url=None)
+
+        except Exception as e:
+            print(f"Error fetching from Spotify: {e}")
+            cls.set(image_url=None)
+
     @classmethod
     def grab(cls):
         cls._grab_subsonic()
 
         if cls.artist and cls.album:
-            cls._grab_lastfm()
+            provider = config.METADATA_PROVIDER.upper()
+            
+            if provider == "SPOTIFY":
+                cls._grab_spotify()
+            elif provider == "LASTFM":
+                cls._grab_lastfm()
+            else:
+                print(f"Unknown metadata provider: {provider}. Using Last.fm as fallback.")
+                cls._grab_lastfm()
 
 
 rpc = DiscordRPC(config.DISCORD_CLIENT_ID, config.DISCORD_TOKEN)
 
 time_passed = 5
+
+print(f"Starting with metadata provider: {config.METADATA_PROVIDER}")
 
 while True:
     time.sleep(config.POLLING_TIME)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dotenv==1.0.1
 requests==2.32.2
 websocket-client==1.8.0
+spotipy==2.24.0


### PR DESCRIPTION
Added Spotify as a Metadata Source using Spotipy. This is configurable using the ENVs `METADATA_PROVIDER` which can be set to LastFM or Spotify, and `SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET` to use Spotipy.

Spotipy does searches looking for the album art, if it fails, it goes through different formatted searches (`search_strategies`) until it finds one that returns an album cover, in my experience it's been more reliable than LastFM getting album covers.

Sorry if I'm doing this wrong, I've never done a PR on GitHub before lol.